### PR TITLE
Prevent XSS (admin cookie hijack).

### DIFF
--- a/form_designer/templates/admin/form_designer/formsubmission/change_form.html
+++ b/form_designer/templates/admin/form_designer/formsubmission/change_form.html
@@ -1,5 +1,13 @@
 {% extends "admin/change_form.html" %}
 
 {% block after_related_objects %}
-<div style="padding: 10px; border: 1px solid #CCC">{{ original.formatted_data_html|safe }}</div>
+<table>
+<tbody>
+{% for key,val in original.sorted_data.items %}
+  <tr class="{% cycle 'even' 'odd' %}">
+      <td> <b>{{ key }}</b> </td> <td> {{ val }} </td>
+  </tr>
+  {% endfor %}
+</tbody>
+</table>   
 {% endblock %}


### PR DESCRIPTION
Render table directly in template without html safe, because value could be cookie hijack !

If something would like to trust directly submited html from user(for example field clean etc..), can change template.

Could be tested with simple ``<script>alert(1)</script>``

It's dangerous only for SESSION_COOKIE_HTTPONLY = False, but still you can exploit the admin using 
http://beefproject.com/