### PR TITLE
Modify `get_form` to allow the admin class to use a custom form.

### DIFF
--- a/form_designer/admin.py
+++ b/form_designer/admin.py
@@ -141,10 +141,10 @@ class FormAdmin(admin.ModelAdmin):
             # Generate a new class with the _current_ request as a class variable
             # form_class = super(FormAdmin, self).get_form(request, obj, **kwargs)
             form_class = modelform_factory(
-                models.Form, form=FormAdminForm, fields="__all__"
+                self.model, form=self.form, fields="__all__"
             )
             request._formdesigner_form_class = type(
-                "FormAdminForm",
+                self.form.__name__,
                 (form_class,),
                 {"request": request},
             )


### PR DESCRIPTION
Previously, it wasn't possible for a user to easily use their own form on the admin due to how `get_form` was implemented.

This change will allow a user to subclass `FormAdminForm` and use it on their custom admin class more easily