### PR TITLE
tests, showcasing non working defaults for radios/dropdowns

### DIFF
--- a/form_designer/models.py
+++ b/form_designer/models.py
@@ -257,6 +257,7 @@ class FormField(models.Model):
         )
         if self.choices:
             kwargs["choices"] = self.get_choices()
+            kwargs["initial"] = slugify(self.default_value)
         return self.get_type(**kwargs)
 
 

--- a/form_designer/models.py
+++ b/form_designer/models.py
@@ -257,6 +257,7 @@ class FormField(models.Model):
         )
         if self.choices:
             kwargs["choices"] = self.get_choices()
+            # The value of individual choices is slugified too.
             kwargs["initial"] = slugify(self.default_value)
         return self.get_type(**kwargs)
 

--- a/tests/testapp/test_forms.py
+++ b/tests/testapp/test_forms.py
@@ -69,7 +69,9 @@ class FormsTest(TestCase):
             9,  # csrf, subject, email, checkbox, _formcontent, submit, radio*3
         )
         self.assertContains(response, "<textarea", 1)
-        self.assertContains(response, 'value="two what" required id="id_fc1-radio_1" checked', 1)
+        self.assertContains(
+            response, 'value="two-what" required id="id_fc1-radio_1" checked', 1
+        )
 
         response = self.client.post("/")
 

--- a/tests/testapp/test_forms.py
+++ b/tests/testapp/test_forms.py
@@ -34,13 +34,21 @@ class FormsTest(TestCase):
             type="checkbox",
             is_required=False,
         )
+        form.fields.create(
+            ordering=4,
+            title="Radio Select",
+            name="radio",
+            type="radio",
+            choices="one,two what,three",
+            default_value="two what",
+        )
 
         form_class = form.form_class()
         form_instance = form_class()
 
         self.assertListEqual(
             [field.name for field in form_instance],
-            ["subject", "email", "body", "please-call-me"],
+            ["subject", "email", "body", "please-call-me", "radio"],
         )
 
         page = Page.objects.create(override_url="/", title="")
@@ -58,13 +66,14 @@ class FormsTest(TestCase):
         self.assertContains(
             response,
             "<input",
-            6,  # csrf, subject, email, checkbox, _formcontent, submit
+            9,  # csrf, subject, email, checkbox, _formcontent, submit, radio*3
         )
         self.assertContains(response, "<textarea", 1)
+        self.assertContains(response, 'value="two what" required id="id_fc1-radio_1" checked', 1)
 
         response = self.client.post("/")
 
-        self.assertContains(response, "This field is required", 3)
+        self.assertContains(response, "This field is required", 4)
 
         # Not this form
         response = self.client.post("/", {"_formcontent": -1})
@@ -78,6 +87,7 @@ class FormsTest(TestCase):
                 "fc{0}-subject".format(form.id): "Test",
                 "fc{0}-email".format(form.id): "invalid",
                 "fc{0}-body".format(form.id): "Hello World",
+                "fc{0}-radio".format(form.id): "one",
             },
         )
 
@@ -94,6 +104,7 @@ class FormsTest(TestCase):
                 "fc{0}-subject".format(form.id): "Test",
                 "fc{0}-email".format(form.id): "valid@example.com",
                 "fc{0}-body".format(form.id): "Hello World",
+                "fc{0}-radio".format(form.id): "one",
             },
         )
 
@@ -118,13 +129,14 @@ class FormsTest(TestCase):
 
         self.assertEqual(
             submission.sorted_data(
-                include=("subject", "email", "body", "please-call-me")
+                include=("subject", "email", "body", "please-call-me", "radio")
             ),
             {
                 "subject": "Test",
                 "email": "valid@example.com",
                 "body": "Hello World",
                 "please-call-me": False,
+                "radio": "one",
             },
         )
 


### PR DESCRIPTION
if one removes the " what" from the radio (as value, and as default, and in the assertblock), it will work. At first sight, I dont know why it "doesnt" work.

this PR is a draft, not sure how I would incorporate this and/or refactor the current test suite.