### PR TITLE
Set the default auto field to be AutoField

### DIFF
--- a/form_designer/apps.py
+++ b/form_designer/apps.py
@@ -3,5 +3,7 @@ from django.utils.translation import gettext_lazy as _
 
 
 class FormDesignerConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
+
     name = "form_designer"
     verbose_name = _("Form Designer")


### PR DESCRIPTION
On django 3.2 it creates a migration to be BigAutoField. This fixes it.